### PR TITLE
Database transactions

### DIFF
--- a/src/main/kotlin/db/DB.kt
+++ b/src/main/kotlin/db/DB.kt
@@ -1,6 +1,7 @@
 package db
 
 import com.beust.klaxon.Klaxon
+import models.ChangeListElement
 import models.ChangeProperty
 import java.io.File
 
@@ -67,11 +68,15 @@ object DB {
     }
 
     val changedObjects = mutableMapOf<ChangeListener<Any?>, ChangeProperty<*>>()
+    val changedLists = mutableMapOf<ElementChangedListener<Any?>, ChangeListElement<*>>()
     fun commit(transaction: () -> Unit) {
         transaction()
         try {
             changedObjects.forEach {
                 it.key(it.value.prop, it.value.old, it.value.new)
+            }
+            changedLists.forEach {
+                it.key(it.value.type, it.value.element)
             }
         } catch (ex: Exception) {
             changedObjects.forEach {

--- a/src/main/kotlin/db/DB.kt
+++ b/src/main/kotlin/db/DB.kt
@@ -3,6 +3,7 @@ package db
 import com.beust.klaxon.Json
 import com.beust.klaxon.JsonArray
 import com.beust.klaxon.Klaxon
+import models.ChangeProperty
 import java.io.File
 import java.io.FileReader
 import java.nio.file.FileSystem

--- a/src/main/kotlin/db/DB.kt
+++ b/src/main/kotlin/db/DB.kt
@@ -69,6 +69,19 @@ object DB{
 
     }
 
+    val changed = mutableMapOf<ChangeListener<Any?>, ChangeProperty<*>>()
+    fun commit(transaction: () -> Unit) {
+        transaction()
+        try {
+            changed.forEach {
+                it.key(it.value.prop, it.value.old, it.value.new)
+            }
+        } catch(ex: Exception) {
+            changed.forEach {
+                it.key(it.value.prop, it.value.old, it.value.old)
+            }
+        }
+    }
 }
 
 fun userdir() = File(System.getProperty("user.dir"))

--- a/src/main/kotlin/db/DB.kt
+++ b/src/main/kotlin/db/DB.kt
@@ -78,10 +78,14 @@ object DB {
             changedLists.forEach {
                 it.key(it.value.type, it.value.element)
             }
+            changedObjects.clear()
+            changedLists.clear()
         } catch (ex: Exception) {
             changedObjects.forEach {
                 it.key(it.value.prop, it.value.old, it.value.old)
             }
+            changedObjects.clear()
+            changedLists.clear()
         }
     }
 }

--- a/src/main/kotlin/db/Observable.kt
+++ b/src/main/kotlin/db/Observable.kt
@@ -22,12 +22,17 @@ abstract class Observable{
     val classListeners = mutableListOf<GeneralChangeListener>()
 
     fun <T : Any?> changed(prop: KProperty<*>, old: T, new: T){
-//        println("${prop.name}: $old -> $new")
+        println("${prop.name}: $old -> $new")
         if(listeners.containsKey(prop.name)){
             val list = listeners[prop.name]!! as List<ChangeListener<T>>
-            list.forEach { it(prop, old, new) }
+            list.forEach {
+                DB.changed[(it as ChangeListener<Any?>)] = ChangeProperty(prop,old,new)
+            }
         }
-        (classListeners as List<ChangeListener<T>>).forEach { it(prop, old, new) }
+
+        (classListeners as List<ChangeListener<T>>).forEach {
+            DB.changed[it as ChangeListener<Any?>] = ChangeProperty(prop,old,new)
+        }
     }
 
     fun <T> addListener(prop: KProperty<T>, listener: ChangeListener<T>){

--- a/src/main/kotlin/db/Observable.kt
+++ b/src/main/kotlin/db/Observable.kt
@@ -1,13 +1,12 @@
 package db
 
 import com.beust.klaxon.Json
-import java.lang.reflect.Proxy
+import models.ChangeProperty
 import kotlin.reflect.KProperty
 import kotlin.properties.ObservableProperty
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.memberProperties
-import kotlin.system.measureTimeMillis
 
 typealias ChangeListener<T> = (prop: KProperty<*>, old: T, new: T) -> Unit
 
@@ -26,12 +25,12 @@ abstract class Observable{
         if(listeners.containsKey(prop.name)){
             val list = listeners[prop.name]!! as List<ChangeListener<T>>
             list.forEach {
-                DB.changed[(it as ChangeListener<Any?>)] = ChangeProperty(prop,old,new)
+                DB.changedObjects[(it as ChangeListener<Any?>)] = ChangeProperty(prop,old,new)
             }
         }
 
         (classListeners as List<ChangeListener<T>>).forEach {
-            DB.changed[it as ChangeListener<Any?>] = ChangeProperty(prop,old,new)
+            DB.changedObjects[it as ChangeListener<Any?>] = ChangeProperty(prop,old,new)
         }
     }
 

--- a/src/main/kotlin/db/ObservableList.kt
+++ b/src/main/kotlin/db/ObservableList.kt
@@ -1,5 +1,7 @@
 package db
 
+import models.ChangeListElement
+
 typealias ElementChangedListener<X> = (ElementChangeType, X) -> Unit
 
 enum class ElementChangeType{
@@ -22,7 +24,9 @@ class ObservableArrayList<X : Observable>{
     private val listeners = mutableListOf<ElementChangedListener<X>>()
 
     private fun signalChanged(type: ElementChangeType, element: X){
-        listeners.forEach { it(type, element) }
+        listeners.forEach {
+            DB.changedLists[it as ElementChangedListener<Any?>] = ChangeListElement(type, element)
+        }
     }
 
     fun addListener(f: ElementChangedListener<X>){

--- a/src/main/kotlin/db/ObservableList.kt
+++ b/src/main/kotlin/db/ObservableList.kt
@@ -22,7 +22,7 @@ class ObservableArrayList<X : Observable>{
     private val listeners = mutableListOf<ElementChangedListener<X>>()
 
     private fun signalChanged(type: ElementChangeType, element: X){
-        listeners.forEach { it.invoke(type, element) }
+        listeners.forEach { it(type, element) }
     }
 
     fun addListener(f: ElementChangedListener<X>){

--- a/src/main/kotlin/example/Example.kt
+++ b/src/main/kotlin/example/Example.kt
@@ -24,6 +24,7 @@ class PersonObserver(t: Person) : ChangeObserver<Person>(t){
 
 }
 
+typealias db = DB
 fun main() {
 
     val obj = DB.getObject("person") {
@@ -51,5 +52,10 @@ fun main() {
     // #####
     //look into data/tournaments.json
     // #####
+
+
+    db.commit {
+        p2.name = "John Doe"
+    }
 
 }

--- a/src/main/kotlin/models/ChangeListElement.kt
+++ b/src/main/kotlin/models/ChangeListElement.kt
@@ -1,0 +1,8 @@
+package models
+
+import db.ElementChangeType
+
+data class ChangeListElement<T>(
+        val type: ElementChangeType,
+        val element: T
+)

--- a/src/main/kotlin/models/ChangeProperty.kt
+++ b/src/main/kotlin/models/ChangeProperty.kt
@@ -1,0 +1,9 @@
+package models
+
+import kotlin.reflect.KProperty
+
+data class ChangeProperty<T>(
+        val prop: KProperty<*>,
+        val old: T,
+        val new: T
+)


### PR DESCRIPTION
Related to issue #1 

Implements transactions with the following syntax:

```kotlin
p1.description = "Some description"
p2.description = "Delicious cake"

DB.commit {
    p1.name = "John Doe"
    p2.name = "Jane Doe"
    ....
}
```

I decided on `.commit{}` instead of `.tx{}` as it felt more in line with its usage paradigm, because while properties can be modified outside of the lambda, they will only get written to the database when calling `.commit{}`.